### PR TITLE
Set upstream metadata fields: Bug-Submit

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+xxhash (0.7.3-3) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Submit.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 07 May 2020 05:48:47 +0000
+
 xxhash (0.7.3-2) unstable; urgency=medium
 
   [ Chris Lamb ]

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,3 +1,4 @@
 Bug-Database: https://github.com/Cyan4973/xxHash/issues
+Bug-Submit: https://github.com/Cyan4973/xxHash/issues/new
 Repository: https://github.com/Cyan4973/xxHash.git
 Repository-Browse: https://github.com/Cyan4973/xxHash


### PR DESCRIPTION
Set upstream metadata fields: Bug-Submit. ([upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html))

This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/xxhash/d50d6d1f-22e3-4b7d-a021-f4a960dc99f3.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/d50d6d1f-22e3-4b7d-a021-f4a960dc99f3/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/d50d6d1f-22e3-4b7d-a021-f4a960dc99f3/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/d50d6d1f-22e3-4b7d-a021-f4a960dc99f3/diffoscope)).
