### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,13 @@
+xxhash (0.8.0-3) UNRELEASED; urgency=medium
+
+  * Trim trailing whitespace.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sun, 05 Sep 2021 08:02:06 -0000
+
 xxhash (0.8.0-2) unstable; urgency=medium
 
   * Use hardware-accelerated XXH3 computation on x86 architecture, and
-    install the hardware-accelerating header file. 
+    install the hardware-accelerating header file.
     Thanks to Julian Andres Klode. (Closes: #977345)
   * Cherry-pick upstream: Fix empty version in .pc file (Closes: #979758)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 xxhash (0.8.0-3) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
+  * Update standards version to 4.5.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sun, 05 Sep 2021 08:02:06 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: utils
 Priority: optional
 Maintainer: Norbert Preining <norbert@preining.info>
 Build-Depends: debhelper-compat (= 12), dpkg-dev (>= 1.16.2)
-Standards-Version: 4.5.0
+Standards-Version: 4.5.1
 Homepage: https://cyan4973.github.io/xxHash
 Vcs-Git: https://github.com/norbusan/debian-xxhash.git
 Vcs-Browser: https://github.com/norbusan/debian-xxhash


### PR DESCRIPTION
Fix some issues reported by lintian

* Trim trailing whitespace. ([trailing-whitespace](https://lintian.debian.org/tags/trailing-whitespace))

* Update standards version to 4.5.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/xxhash/9b9672fd-eeac-466e-8b72-4498e32a72c1.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/33/35e8fdcf8c8156e63fd57e58ab0c9d8cf251ef.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/d9/92b2a58c7eeca392028c2ddb446b121f53ef32.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/35/0c4fe17bad70bc5c10f635f57be5d2ebd67af7.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/b0/5a38f8c630928c32aa95c1ea931619f388c911.debug

No differences were encountered between the control files of package \*\*libxxhash-dev\*\*

No differences were encountered between the control files of package \*\*libxxhash0\*\*
### Control files of package libxxhash0-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-b05a38f8c630928c32aa95c1ea931619f388c911-] {+3335e8fdcf8c8156e63fd57e58ab0c9d8cf251ef+}

No differences were encountered between the control files of package \*\*xxhash\*\*
### Control files of package xxhash-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-350c4fe17bad70bc5c10f635f57be5d2ebd67af7-] {+d992b2a58c7eeca392028c2ddb446b121f53ef32+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/9b9672fd-eeac-466e-8b72-4498e32a72c1/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/9b9672fd-eeac-466e-8b72-4498e32a72c1/diffoscope)).
